### PR TITLE
Revert "rm: `bt-a2dp` and `ffstream` (#10)"

### DIFF
--- a/hotfixes.json
+++ b/hotfixes.json
@@ -6,7 +6,7 @@
     },
     "ffstream": {
         "script": "scripts/streaming.sh",
-        "description": "Repairs Firefox streaming issues",
+        "description": "Repairs Firefox streaming issues in 2025.{1,2} images",
         "published": "2025-02-24"
     },
     "nix-bin": {

--- a/hotfixes.json
+++ b/hotfixes.json
@@ -6,7 +6,7 @@
     },
     "ffstream": {
         "script": "scripts/streaming.sh",
-        "description": "Repairs Firefox streaming issues on 2025.1/2025.2 images",
+        "description": "Repairs Firefox streaming issues",
         "published": "2025-02-24"
     },
     "nix-bin": {

--- a/hotfixes.json
+++ b/hotfixes.json
@@ -6,7 +6,7 @@
     },
     "ffstream": {
         "script": "scripts/streaming.sh",
-        "description": "Repairs Firefox streaming issues in 2025.{1,2} images",
+        "description": "Repairs Firefox streaming issues",
         "published": "2025-02-24"
     },
     "nix-bin": {

--- a/hotfixes.json
+++ b/hotfixes.json
@@ -1,4 +1,14 @@
 {
+    "bt-a2dp": {
+        "script": "scripts/btcodec.sh",
+        "description": "Repairs A2DP profiles with Bluetooth Audio",
+        "published": "2025-03-04"
+    },
+    "ffstream": {
+        "script": "scripts/streaming.sh",
+        "description": "Repairs Firefox streaming issues on 2025.1/2025.2 images",
+        "published": "2025-02-24"
+    },
     "nix-bin": {
         "script": "scripts/nix-bin.sh",
         "description": "Repairs nix-bin segfaults in 2025.3 images",

--- a/scripts/btcodec.sh
+++ b/scripts/btcodec.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+hotfix() {
+  sudo apt remove bluez-alsa-utils -y
+}

--- a/scripts/streaming.sh
+++ b/scripts/streaming.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+hotfix() {
+  sudo apt-get update && sudo apt-get install --reinstall libsnappy1v5 -y
+}


### PR DESCRIPTION
Keep them for legacy installs